### PR TITLE
Added support for IAsyncEnumerable<> / IAsyncQueryProvider to ef core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
 
 install:
   - export DOTNET_INSTALL_DIR="$PWD/.dotnetcli"
-  - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel LTS --version latest --install-dir "$DOTNET_INSTALL_DIR"
+  - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 9.0 --version latest --install-dir "$DOTNET_INSTALL_DIR"
   - export PATH="$DOTNET_INSTALL_DIR:$PATH"
   - if test "$TRAVIS_OS_NAME" == "osx"; then export DYLD_LIBRARY_PATH=/usr/local/opt/openssl/lib; fi
 
@@ -39,4 +39,4 @@ before_script:
   - dotnet --info
 
 script:
-  - dotnet test Remote.Linq.sln -c $CONFIGURATION -f net8.0
+  - dotnet test Remote.Linq.sln -c $CONFIGURATION -f net9.0

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -61,7 +61,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="aqua.tool.Validation" Version="3.1.0">
+    <PackageReference Include="aqua.tool.Validation" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "9.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -21,6 +21,7 @@
     <ApplicationIcon>$(MSBuildThisFileDirectory)..\remotelinq-w.ico</ApplicationIcon>
     <EnableFxCopAnalyzers>false</EnableFxCopAnalyzers>
     <EnableSonarAnalyzers>false</EnableSonarAnalyzers>
+    <NuGetAudit>false</NuGetAudit>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/SharedCode/Common.BinaryDataFormatter.cs
+++ b/samples/SharedCode/Common.BinaryDataFormatter.cs
@@ -33,7 +33,11 @@ public static class BinaryDataFormatter
     {
         byte[] bytes = new byte[256];
 
-        stream.Read(bytes, 0, 8);
+        if (stream.Read(bytes, 0, 8) != 8)
+        {
+            throw new InvalidOperationException("Could not read data from stream!");
+        }
+
         long size = BitConverter.ToInt64(bytes, 0);
 
         bool isException = stream.ReadByte() != 0;

--- a/src/Remote.Linq.EntityFrameworkCore/DynamicQuery/IRemoteLinqEfCoreAsyncQueryProvider.cs
+++ b/src/Remote.Linq.EntityFrameworkCore/DynamicQuery/IRemoteLinqEfCoreAsyncQueryProvider.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Christof Senn. All rights reserved. See license.txt in the project root for license information.
+
+namespace Remote.Linq.EntityFrameworkCore.DynamicQuery;
+
+#if NETSTANDARD2_1_OR_GREATER || NET8_0_OR_GREATER
+using IAsyncQueryProvider = Microsoft.EntityFrameworkCore.Query.IAsyncQueryProvider;
+#else
+using IAsyncQueryProvider = Microsoft.EntityFrameworkCore.Query.Internal.IAsyncQueryProvider;
+#endif
+
+/// <summary>
+/// Represents a query provider for <i>Remote.Linq</i> version of asynchronous queryable sequences.
+/// </summary>
+public interface IRemoteLinqEfCoreAsyncQueryProvider : IAsyncQueryProvider, IAsyncRemoteStreamProvider, IAsyncRemoteQueryProvider, IRemoteQueryProvider
+{
+}

--- a/src/Remote.Linq.EntityFrameworkCore/DynamicQuery/RemoteLinqEfCoreAsyncQueryProvider.cs
+++ b/src/Remote.Linq.EntityFrameworkCore/DynamicQuery/RemoteLinqEfCoreAsyncQueryProvider.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Christof Senn. All rights reserved. See license.txt in the project root for license information.
+
+namespace Remote.Linq.EntityFrameworkCore.DynamicQuery;
+
+using Aqua.TypeExtensions;
+using System.Threading.Tasks;
+using MethodInfo = System.Reflection.MethodInfo;
+
+internal static class RemoteLinqEfCoreAsyncQueryProvider
+{
+    public static readonly MethodInfo TaskFromResultMethodInfo =
+        typeof(Task).GetMethodEx(nameof(Task.FromResult));
+}

--- a/src/Remote.Linq.EntityFrameworkCore/DynamicQuery/RemoteLinqEfCoreAsyncQueryProvider`1.cs
+++ b/src/Remote.Linq.EntityFrameworkCore/DynamicQuery/RemoteLinqEfCoreAsyncQueryProvider`1.cs
@@ -35,9 +35,6 @@ public sealed class RemoteLinqEfCoreAsyncQueryProvider<TSource> : IRemoteLinqEfC
     private static readonly MethodInfo _mapElementStreamMethodInfo =
         typeof(RemoteLinqEfCoreAsyncQueryProvider<TSource>).GetMethodEx(nameof(MapElementStreamInternal));
 
-    private static readonly MethodInfo _taskFromResultMethodInfo =
-        typeof(Task).GetMethodEx(nameof(Task.FromResult));
-
     private readonly Func<RemoteLinq.Expression, CancellationToken, ValueTask<TSource?>>? _asyncDataProvider;
     private readonly IAsyncQueryResultMapper<TSource> _resultMapper;
     private readonly IExpressionToRemoteLinqContext _context;
@@ -153,5 +150,5 @@ public sealed class RemoteLinqEfCoreAsyncQueryProvider<TSource> : IRemoteLinqEfC
     }
 
     private static TResult WrapIntoTypedTask<TResult>(Type innerType, object objectToWrap)
-        => (TResult)_taskFromResultMethodInfo.MakeGenericMethod(innerType).Invoke(null, [objectToWrap])!;
+        => (TResult)RemoteLinqEfCoreAsyncQueryProvider.TaskFromResultMethodInfo.MakeGenericMethod(innerType).Invoke(null, [objectToWrap])!;
 }

--- a/src/Remote.Linq.EntityFrameworkCore/DynamicQuery/RemoteLinqEfCoreAsyncQueryProvider`1.cs
+++ b/src/Remote.Linq.EntityFrameworkCore/DynamicQuery/RemoteLinqEfCoreAsyncQueryProvider`1.cs
@@ -1,0 +1,157 @@
+﻿// Copyright (c) Christof Senn. All rights reserved. See license.txt in the project root for license information.
+
+namespace Remote.Linq.EntityFrameworkCore.DynamicQuery;
+
+using Aqua.TypeExtensions;
+using Remote.Linq.DynamicQuery;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
+using System.Security;
+using System.Threading;
+using System.Threading.Tasks;
+using MethodInfo = System.Reflection.MethodInfo;
+using RemoteLinq = Remote.Linq.Expressions;
+
+#if NETSTANDARD2_1_OR_GREATER || NET8_0_OR_GREATER
+using IAsyncQueryProvider = Microsoft.EntityFrameworkCore.Query.IAsyncQueryProvider;
+#else
+using IAsyncQueryProvider = Microsoft.EntityFrameworkCore.Query.Internal.IAsyncQueryProvider;
+#endif
+
+/// <summary>
+/// Represents a query provider for <i>Remote.Linq</i> version of asynchronous queryable sequences.
+/// </summary>
+public sealed class RemoteLinqEfCoreAsyncQueryProvider<TSource> : IRemoteLinqEfCoreAsyncQueryProvider
+{
+    private static readonly MethodInfo _executeMethod = typeof(RemoteLinqEfCoreAsyncQueryProvider<TSource>)
+        .GetMethodEx(nameof(ExecuteAsyncInternal), [typeof(object)], typeof(Expression), typeof(CancellationToken));
+
+    private static readonly MethodInfo _mapElementStreamToAsyncEnumerableMethodInfo =
+        typeof(RemoteLinqEfCoreAsyncQueryProvider<TSource>).GetMethodEx(nameof(MapElementStreamToAsyncEnumerableInternal));
+
+    private static readonly MethodInfo _mapElementStreamMethodInfo =
+        typeof(RemoteLinqEfCoreAsyncQueryProvider<TSource>).GetMethodEx(nameof(MapElementStreamInternal));
+
+    private static readonly MethodInfo _taskFromResultMethodInfo =
+        typeof(Task).GetMethodEx(nameof(Task.FromResult));
+
+    private readonly Func<RemoteLinq.Expression, CancellationToken, ValueTask<TSource?>>? _asyncDataProvider;
+    private readonly IAsyncQueryResultMapper<TSource> _resultMapper;
+    private readonly IExpressionToRemoteLinqContext _context;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RemoteLinqEfCoreAsyncQueryProvider{TSource}"/> class.
+    /// </summary>
+    [SecuritySafeCritical]
+    public RemoteLinqEfCoreAsyncQueryProvider(
+        Func<RemoteLinq.Expression, CancellationToken, ValueTask<TSource?>> asyncDataProvider,
+        IExpressionToRemoteLinqContext? context,
+        IAsyncQueryResultMapper<TSource> resultMapper)
+    {
+        _asyncDataProvider = asyncDataProvider.CheckNotNull();
+        _context = context ?? ExpressionTranslatorContext.Default;
+        _resultMapper = resultMapper.CheckNotNull();
+    }
+
+    IQueryable IQueryProvider.CreateQuery(Expression expression)
+        => RemoteLinqEfCoreAsyncQueryable.CreateNonGeneric(this, expression);
+
+    IQueryable<TElement> IQueryProvider.CreateQuery<TElement>(Expression expression)
+        => new RemoteLinqEfCoreAsyncQueryable<TElement>(this, expression);
+
+    object? IQueryProvider.Execute(Expression expression)
+        => _executeMethod.MakeGenericMethod(typeof(IQueryable).IsAssignableFrom(expression.Type) ? typeof(object) : expression.Type).Invoke(this, [expression, CancellationToken.None]);
+
+    TResult IQueryProvider.Execute<TResult>(Expression expression)
+        => ExecuteAsyncInternal<TResult>(expression, CancellationToken.None);
+
+    public TResult ExecuteAsyncInternal<TResult>(Expression expression, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var rlinq = _context.ExpressionTranslator.TranslateExpression(expression);
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (typeof(TResult).IsGenericType && typeof(TResult).GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>))
+        {
+            var resultItemType = typeof(TResult).GenericTypeArguments[0];
+
+            return MapElementStreamToAsyncEnumerable<TResult>(resultItemType, expression, rlinq, cancellationToken);
+        }
+
+        if (typeof(TResult).IsGenericType && typeof(TResult).GetGenericTypeDefinition() == typeof(Task<>))
+        {
+            var genericTaskArgument = typeof(TResult).GenericTypeArguments[0];
+
+            if (genericTaskArgument.IsGenericType && genericTaskArgument.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>))
+            {
+                var resultItemType = genericTaskArgument.GenericTypeArguments[0];
+
+                return WrapIntoTypedTask<TResult>(genericTaskArgument, MapElementStreamToAsyncEnumerable<object>(resultItemType, expression, rlinq, cancellationToken));
+            }
+
+            return MapElementStream<TResult>(genericTaskArgument, expression, rlinq, cancellationToken);
+        }
+
+        return MapElementStream<Task<TResult>>(typeof(TResult), expression, rlinq, cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult();
+    }
+
+    TResult IAsyncQueryProvider.ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken)
+        => ExecuteAsyncInternal<TResult>(expression, cancellationToken);
+
+    async ValueTask<TResult> IAsyncRemoteQueryProvider.ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken)
+       => await ExecuteAsyncInternal<Task<TResult>>(expression, cancellationToken).ConfigureAwait(false);
+
+    IAsyncEnumerable<T> IAsyncRemoteStreamProvider.ExecuteAsyncRemoteStream<T>(Expression expression, CancellationToken cancellationToken)
+       => ExecuteAsyncInternal<IAsyncEnumerable<T>>(expression, cancellationToken);
+
+    private TResult MapElementStreamToAsyncEnumerable<TResult>(Type elementType, Expression expression, RemoteLinq.Expression rlinq, CancellationToken cancellationToken)
+    {
+        ExpressionHelper.CheckExpressionResultType(elementType, expression);
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var method = _mapElementStreamToAsyncEnumerableMethodInfo.MakeGenericMethod(elementType);
+        var result = method.Invoke(null, [expression, rlinq, _asyncDataProvider, _resultMapper, cancellationToken]);
+        return (TResult)result!;
+    }
+
+    private static async IAsyncEnumerable<T> MapElementStreamToAsyncEnumerableInternal<T>(Expression expression, RemoteLinq.Expression rlinq, Func<RemoteLinq.Expression, CancellationToken, ValueTask<TSource?>> asyncDataProvider, IAsyncQueryResultMapper<TSource?> resultMapper, [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var transferRecords = await asyncDataProvider(rlinq, cancellationToken).ConfigureAwait(false);
+        var mappedResult = await resultMapper.MapResultAsync<IEnumerable<T>>(transferRecords, expression, cancellationToken).ConfigureAwait(false);
+
+        foreach (var item in mappedResult)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return item;
+        }
+    }
+
+    private TResult MapElementStream<TResult>(Type mapResultType, Expression expression, RemoteLinq.Expression rlinq, CancellationToken cancellationToken)
+    {
+        ExpressionHelper.CheckExpressionResultType(mapResultType, expression);
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var method = _mapElementStreamMethodInfo.MakeGenericMethod(mapResultType);
+        var result = method.Invoke(null, [expression, rlinq, _asyncDataProvider, _resultMapper, cancellationToken]);
+        return (TResult)result!;
+    }
+
+    private static async Task<T> MapElementStreamInternal<T>(Expression expression, RemoteLinq.Expression rlinq, Func<RemoteLinq.Expression, CancellationToken, ValueTask<TSource?>> asyncDataProvider, IAsyncQueryResultMapper<TSource?> resultMapper, CancellationToken cancellationToken)
+    {
+        var dataRecords = await asyncDataProvider(rlinq, cancellationToken).ConfigureAwait(false);
+
+        var result = await resultMapper.MapResultAsync<T>(dataRecords, expression, cancellationToken).ConfigureAwait(false);
+
+        return result;
+    }
+
+    private static TResult WrapIntoTypedTask<TResult>(Type innerType, object objectToWrap)
+        => (TResult)_taskFromResultMethodInfo.MakeGenericMethod(innerType).Invoke(null, [objectToWrap])!;
+}

--- a/src/Remote.Linq.EntityFrameworkCore/DynamicQuery/RemoteLinqEfCoreAsyncQueryable.cs
+++ b/src/Remote.Linq.EntityFrameworkCore/DynamicQuery/RemoteLinqEfCoreAsyncQueryable.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Christof Senn. All rights reserved. See license.txt in the project root for license information.
+
+namespace Remote.Linq.EntityFrameworkCore.DynamicQuery;
+
+using Aqua.TypeSystem;
+using System;
+using System.Collections.Concurrent;
+using System.Linq.Expressions;
+
+public static class RemoteLinqEfCoreAsyncQueryable
+{
+    private static ConcurrentDictionary<Type, Func<IRemoteLinqEfCoreAsyncQueryProvider, Expression?, IAsyncRemoteQueryable>> _genericConstructorCache = new();
+
+    public static IAsyncRemoteQueryable CreateNonGeneric(IRemoteLinqEfCoreAsyncQueryProvider provider, Expression expression)
+    {
+        var elementType = TypeHelper.GetElementType(expression.Type)
+          ?? throw new RemoteLinqException($"Cannot get element type based on expression's type {expression.Type}");
+
+        return CreateNonGeneric(elementType, provider, expression);
+    }
+
+    public static IAsyncRemoteQueryable CreateNonGeneric(Type elementType, IRemoteLinqEfCoreAsyncQueryProvider provider, Expression? expression)
+    {
+        var genericConstructor = _genericConstructorCache.GetOrAdd(
+            elementType,
+            x =>
+            {
+                var providerParameter = Expression.Parameter(typeof(IRemoteLinqEfCoreAsyncQueryProvider), nameof(provider));
+                var expressionParameter = Expression.Parameter(typeof(Expression), nameof(expression));
+
+                var genericType = typeof(RemoteLinqEfCoreAsyncQueryable<>).MakeGenericType(elementType);
+                var constructor = genericType.GetConstructors()[0];
+
+                return Expression.Lambda<Func<IRemoteLinqEfCoreAsyncQueryProvider, Expression?, IAsyncRemoteQueryable>>(Expression.New(constructor, providerParameter, expressionParameter), providerParameter, expressionParameter).Compile();
+            });
+
+        return genericConstructor(provider, expression);
+    }
+}

--- a/src/Remote.Linq.EntityFrameworkCore/DynamicQuery/RemoteLinqEfCoreAsyncQueryable`1.cs
+++ b/src/Remote.Linq.EntityFrameworkCore/DynamicQuery/RemoteLinqEfCoreAsyncQueryable`1.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Christof Senn. All rights reserved. See license.txt in the project root for license information.
+
+namespace Remote.Linq.EntityFrameworkCore.DynamicQuery;
+
+using Remote.Linq.DynamicQuery;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+/// <summary>
+/// A <i>Remote.Linq</i> queryable for async remote execution of EntityFrameworkCore queries.
+/// </summary>
+public class RemoteLinqEfCoreAsyncQueryable<T> : AsyncRemoteQueryable<T>, IAsyncEnumerable<T>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RemoteLinqEfCoreAsyncQueryable{T}"/> class.
+    /// </summary>
+    public RemoteLinqEfCoreAsyncQueryable(IRemoteLinqEfCoreAsyncQueryProvider provider, Expression? expression)
+        : base(provider, expression)
+    {
+    }
+
+    /// <inheritdoc/>
+    public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+    {
+        var result = ((IRemoteLinqEfCoreAsyncQueryProvider)Provider).ExecuteAsyncRemoteStream<T>(Expression, cancellationToken).ConfigureAwait(false);
+        await foreach (var item in result.WithCancellation(cancellationToken))
+        {
+            yield return item;
+        }
+    }
+}

--- a/src/Remote.Linq.EntityFrameworkCore/Remote.Linq.EntityFrameworkCore.csproj
+++ b/src/Remote.Linq.EntityFrameworkCore/Remote.Linq.EntityFrameworkCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0</TargetFrameworks>
     <PackageTags>LINQ,expression-tree,lambda,dynamic,remote,remote-query,multi-tier,n-tier,fluent-interface,entity-framework-core,entity-framework,ef-core,ef</PackageTags>
     <Description>
       Remote linq extensions for EF Core.
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.32" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.17" Condition="'$(TargetFramework)' == 'netstandard2.1'" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net9.0'" />
   </ItemGroup>
 
 </Project>

--- a/src/Remote.Linq.Text.Json/Remote.Linq.Text.Json.csproj
+++ b/src/Remote.Linq.Text.Json/Remote.Linq.Text.Json.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <PackageTags>remote-linq;json;system-text-json</PackageTags>
     <Description>Provides System.Text.Json serialization for Remote.Linq types.</Description>
     <IncludeGlobalAssemblyInfo>false</IncludeGlobalAssemblyInfo>

--- a/src/Remote.Linq/DynamicQuery/AsyncRemoteQueryable.cs
+++ b/src/Remote.Linq/DynamicQuery/AsyncRemoteQueryable.cs
@@ -13,8 +13,8 @@ public class AsyncRemoteQueryable : RemoteQueryable, IOrderedAsyncRemoteQueryabl
     /// <summary>
     /// Initializes a new instance of the <see cref="AsyncRemoteQueryable"/> class.
     /// </summary>
-    public AsyncRemoteQueryable(Type elemntType, IAsyncRemoteQueryProvider provider, Expression? expression = null)
-        : base(elemntType, provider, expression)
+    public AsyncRemoteQueryable(Type elementType, IAsyncRemoteQueryProvider provider, Expression? expression = null)
+        : base(elementType, provider, expression)
     {
     }
 

--- a/src/Remote.Linq/DynamicQuery/AsyncRemoteQueryable`1.cs
+++ b/src/Remote.Linq/DynamicQuery/AsyncRemoteQueryable`1.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 /// <summary>
 /// Provides functionality to compose queries for async remote execution.
 /// </summary>
-public sealed class AsyncRemoteQueryable<T> : AsyncRemoteQueryable, IOrderedAsyncRemoteQueryable<T>
+public class AsyncRemoteQueryable<T> : AsyncRemoteQueryable, IOrderedAsyncRemoteQueryable<T>
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="AsyncRemoteQueryable{T}"/> class.

--- a/src/Remote.Linq/DynamicQuery/ExpressionHelper.cs
+++ b/src/Remote.Linq/DynamicQuery/ExpressionHelper.cs
@@ -15,9 +15,17 @@ public static class ExpressionHelper
     /// throws an <see cref="ArgumentException"/> otherwise.
     /// </summary>
     public static void CheckExpressionResultType<TResult>(SystemExpression expression)
+       => CheckExpressionResultType(typeof(TResult), expression);
+
+    /// <summary>
+    /// Checks whether the give <see cref="SystemExpression"/> is assignable
+    /// to the given <cparam name="resultType"/> type in any form,
+    /// throws an <see cref="ArgumentException"/> otherwise.
+    /// </summary>
+    public static void CheckExpressionResultType(Type resultType, SystemExpression expression)
     {
         var expressionType = expression.CheckNotNull().Type;
-        if (typeof(TResult).IsAssignableFrom(expressionType))
+        if (resultType.IsAssignableFrom(expressionType))
         {
             return;
         }
@@ -29,7 +37,7 @@ public static class ExpressionHelper
 
         if (expressionType.Implements(typeof(IQueryable<>), out var typeArgs) &&
             typeArgs.Length is 1 &&
-            typeof(TResult).IsAssignableFrom(typeArgs[0]))
+            resultType.IsAssignableFrom(typeArgs[0]))
         {
             return;
         }

--- a/src/Remote.Linq/DynamicQuery/RemoteQueryable.cs
+++ b/src/Remote.Linq/DynamicQuery/RemoteQueryable.cs
@@ -15,9 +15,9 @@ public class RemoteQueryable : IOrderedRemoteQueryable
     /// <summary>
     /// Initializes a new instance of the <see cref="RemoteQueryable"/> class.
     /// </summary>
-    public RemoteQueryable(Type elemntType, IRemoteQueryProvider provider, Expression? expression = null)
+    public RemoteQueryable(Type elementType, IRemoteQueryProvider provider, Expression? expression = null)
     {
-        ElementType = elemntType.CheckNotNull();
+        ElementType = elementType.CheckNotNull();
         Provider = provider.CheckNotNull();
         Expression = expression ?? Expression.Constant(this);
     }

--- a/src/Remote.Linq/Remote.Linq.csproj
+++ b/src/Remote.Linq/Remote.Linq.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Summary>Simply LINQ your remote resources...</Summary>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0</TargetFrameworks>
     <PackageTags>LINQ;expression-tree;lambda;dynamic;remote;remote-query;multi-tier;n-tier;fluent-interface</PackageTags>
     <Description>Remote Linq is a small and easy to use - yet very powerful - library to translate linq expression trees to strongly typed, serializable object trees and vice versa. It provides functionality to send arbitrary linq queries to a remote service to be applied and executed against any enumerable or queryable data source.</Description>
   </PropertyGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -13,8 +13,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" PrivateAssets="all" />
     <PackageReference Include="Shouldly" Version="4.2.1" PrivateAssets="all" />
     <PackageReference Include="xunit" Version="2.9.2" PrivateAssets="all" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="all" />
-    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" PrivateAssets="all" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0" PrivateAssets="all" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.23" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/test/Remote.Linq.Async.Queryable.Tests/Remote.Linq.Async.Queryable.Tests.csproj
+++ b/test/Remote.Linq.Async.Queryable.Tests/Remote.Linq.Async.Queryable.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Tests for Remote.Linq.EntityFramework</Description>
-    <TargetFrameworks>net48;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Remote.Linq.EntityFramework.Tests/Remote.Linq.EntityFramework.Tests.csproj
+++ b/test/Remote.Linq.EntityFramework.Tests/Remote.Linq.EntityFramework.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Tests for Remote.Linq.EntityFramework</Description>
-    <TargetFrameworks>net48;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Remote.Linq.EntityFrameworkCore.Tests/Remote.Linq.EntityFrameworkCore.Tests.csproj
+++ b/test/Remote.Linq.EntityFrameworkCore.Tests/Remote.Linq.EntityFrameworkCore.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Tests for Remote.Linq.EntityFrameworkCore</Description>
-    <TargetFrameworks>net48;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.32" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net9.0'" />
   </ItemGroup>
 
 </Project>

--- a/test/Remote.Linq.EntityFrameworkCore.Tests/When_querying_with_efcore_async_functions.cs
+++ b/test/Remote.Linq.EntityFrameworkCore.Tests/When_querying_with_efcore_async_functions.cs
@@ -1,0 +1,283 @@
+﻿// Copyright (c) Christof Senn. All rights reserved. See license.txt in the project root for license information.
+
+namespace Remote.Linq.EntityFrameworkCore.Tests;
+
+using Microsoft.EntityFrameworkCore;
+using Remote.Linq.Async;
+using Remote.Linq.EntityFrameworkCore.Tests.Model;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+public sealed class When_querying_with_efcore_async_functions : IDisposable
+{
+    private readonly TestContext _context;
+    private readonly IQueryable<LookupItem> _queryable;
+
+    public When_querying_with_efcore_async_functions()
+    {
+        _context = new TestContext();
+        _context.Lookup.Add(new LookupItem { Key = "1", Value = "One" });
+        _context.Lookup.Add(new LookupItem { Key = "2", Value = "Two" });
+        _context.Lookup.Add(new LookupItem { Key = "3", Value = "Three" });
+        _context.SaveChanges();
+
+        _queryable = RemoteQueryable.Factory.CreateEntityFrameworkCoreAsyncQueryable<LookupItem>((x, c) => x.ExecuteWithEntityFrameworkCoreAsync(_context, c), context: null);
+    }
+
+    public void Dispose() => _context.Dispose();
+
+    [Fact]
+    public async Task Should_query_multiple()
+    {
+        var results = await EntityFrameworkQueryableExtensions.ToArrayAsync(_queryable.Where(x => x.Value.ToUpper().Contains("O")));
+        var keys = results.Select(x => x.Key).ToArray();
+        keys.ShouldContain("1");
+        keys.ShouldContain("2");
+        keys.Length.ShouldBe(2);
+
+        results = await AsyncQueryableExtensions.ToArrayAsync(_queryable.Where(x => x.Value.ToUpper().Contains("O")));
+        keys = results.Select(x => x.Key).ToArray();
+        keys.ShouldContain("1");
+        keys.ShouldContain("2");
+        keys.Length.ShouldBe(2);
+
+        results = _queryable.Where(x => x.Value.ToUpper().Contains("O")).ToArray();
+        keys = results.Select(x => x.Key).ToArray();
+        keys.ShouldContain("1");
+        keys.ShouldContain("2");
+        keys.Length.ShouldBe(2);
+
+        var resultsList = new List<LookupItem>();
+        await foreach (var result in _queryable.Where(x => x.Value.ToUpper().Contains("O")).AsAsyncEnumerable())
+        {
+            resultsList.Add(result);
+        }
+
+        results = resultsList.ToArray();
+        keys = results.Select(x => x.Key).ToArray();
+        keys.ShouldContain("1");
+        keys.ShouldContain("2");
+        keys.Length.ShouldBe(2);
+
+        resultsList = new List<LookupItem>();
+        foreach (var result in _queryable.Where(x => x.Value.ToUpper().Contains("O")))
+        {
+            resultsList.Add(result);
+        }
+
+        results = resultsList.ToArray();
+        keys = results.Select(x => x.Key).ToArray();
+        keys.ShouldContain("1");
+        keys.ShouldContain("2");
+        keys.Length.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task Should_query_multiple_with_projection()
+    {
+        var results = await EntityFrameworkQueryableExtensions.ToArrayAsync(_queryable.Where(x => x.Value.ToUpper().Contains("O")).Select(x => x.Key));
+        results.ShouldContain("1");
+        results.ShouldContain("2");
+        results.Length.ShouldBe(2);
+
+        results = await AsyncQueryableExtensions.ToArrayAsync(_queryable.Where(x => x.Value.ToUpper().Contains("O")).Select(x => x.Key));
+        results.ShouldContain("1");
+        results.ShouldContain("2");
+        results.Length.ShouldBe(2);
+
+        results = _queryable.Where(x => x.Value.ToUpper().Contains("O")).Select(x => x.Key).ToArray();
+        results.ShouldContain("1");
+        results.ShouldContain("2");
+        results.Length.ShouldBe(2);
+
+        var resultsList = new List<string>();
+        await foreach (var result in _queryable.Where(x => x.Value.ToUpper().Contains("O")).Select(x => x.Key).AsAsyncEnumerable())
+        {
+            resultsList.Add(result);
+        }
+
+        results = resultsList.ToArray();
+        results.ShouldContain("1");
+        results.ShouldContain("2");
+        results.Length.ShouldBe(2);
+
+        resultsList = new List<string>();
+        foreach (var result in _queryable.Where(x => x.Value.ToUpper().Contains("O")).Select(x => x.Key))
+        {
+            resultsList.Add(result);
+        }
+
+        results = resultsList.ToArray();
+        results.ShouldContain("1");
+        results.ShouldContain("2");
+        results.Length.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task Should_query_multiple_with_empty_result()
+    {
+        var results = await EntityFrameworkQueryableExtensions.ToArrayAsync(_queryable.Where(x => x.Value.ToUpper().Contains("no match")));
+        results.ShouldBeEmpty();
+
+        results = await AsyncQueryableExtensions.ToArrayAsync(_queryable.Where(x => x.Value.ToUpper().Contains("no match")));
+        results.ShouldBeEmpty();
+
+        results = _queryable.Where(x => x.Value.ToUpper().Contains("no match")).ToArray();
+        results.ShouldBeEmpty();
+
+        var resultsList = new List<LookupItem>();
+        await foreach (var result in _queryable.Where(x => x.Value.ToUpper().Contains("no match")).AsAsyncEnumerable())
+        {
+            resultsList.Add(result);
+        }
+
+        results = resultsList.ToArray();
+        results.ShouldBeEmpty();
+
+        resultsList = new List<LookupItem>();
+        foreach (var result in _queryable.Where(x => x.Value.ToUpper().Contains("no match")))
+        {
+            resultsList.Add(result);
+        }
+
+        results = resultsList.ToArray();
+        results.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Should_query_single()
+    {
+        var result = await EntityFrameworkQueryableExtensions.SingleAsync(_queryable, x => x.Value.ToUpper().Contains("W"));
+
+        result.Key.ShouldBe("2");
+
+        result = await EntityFrameworkQueryableExtensions.SingleAsync(_queryable.Where(x => x.Value.ToUpper().Contains("W")));
+
+        result.Key.ShouldBe("2");
+
+        result = await AsyncQueryableExtensions.SingleAsync(_queryable, x => x.Value.ToUpper().Contains("W"));
+
+        result.Key.ShouldBe("2");
+
+        result = await AsyncQueryableExtensions.SingleAsync(_queryable.Where(x => x.Value.ToUpper().Contains("W")));
+
+        result.Key.ShouldBe("2");
+
+        result = _queryable.Single(x => x.Value.ToUpper().Contains("W"));
+
+        result.Key.ShouldBe("2");
+
+        result = _queryable.Where(x => x.Value.ToUpper().Contains("W")).Single();
+
+        result.Key.ShouldBe("2");
+    }
+
+    [Fact]
+    public async Task Should_query_single_with_projection()
+    {
+        var result = await EntityFrameworkQueryableExtensions.SingleAsync(_queryable.Where(x => x.Value.ToUpper().Contains("W")).Select(x => x.Key));
+
+        result.ShouldBe("2");
+
+        result = await AsyncQueryableExtensions.SingleAsync(_queryable.Where(x => x.Value.ToUpper().Contains("W")).Select(x => x.Key));
+
+        result.ShouldBe("2");
+
+        result = _queryable.Where(x => x.Value.ToUpper().Contains("W")).Select(x => x.Key).Single();
+
+        result.ShouldBe("2");
+    }
+
+    [Fact]
+    public async Task Should_query_single_with_subquery_predicate()
+    {
+        var result = await EntityFrameworkQueryableExtensions.SingleAsync(_queryable, x => x.Value == _queryable.First().Value);
+
+        result.Key.ShouldBe("1");
+
+        result = await EntityFrameworkQueryableExtensions.SingleAsync(_queryable.Where(x => x.Value == _queryable.First().Value));
+
+        result.Key.ShouldBe("1");
+
+        result = await AsyncQueryableExtensions.SingleAsync(_queryable, x => x.Value == _queryable.First().Value);
+
+        result.Key.ShouldBe("1");
+
+        result = await AsyncQueryableExtensions.SingleAsync(_queryable.Where(x => x.Value == _queryable.First().Value));
+
+        result.Key.ShouldBe("1");
+
+        result = _queryable.Single(x => x.Value == _queryable.First().Value);
+
+        result.Key.ShouldBe("1");
+
+        result = _queryable.Where(x => x.Value == _queryable.First().Value).Single();
+
+        result.Key.ShouldBe("1");
+    }
+
+    [Fact]
+    public async Task SingleOrDefault_with_predicate_should_return_null_if_no_match()
+    {
+        var result = await EntityFrameworkQueryableExtensions.SingleOrDefaultAsync(_queryable, x => x.Value.ToUpper().Contains("no match"));
+
+        result.ShouldBeNull();
+
+        result = await EntityFrameworkQueryableExtensions.SingleOrDefaultAsync(_queryable.Where(x => x.Value.ToUpper().Contains("no match")));
+
+        result.ShouldBeNull();
+
+        result = await AsyncQueryableExtensions.SingleOrDefaultAsync(_queryable, x => x.Value.ToUpper().Contains("no match"));
+
+        result.ShouldBeNull();
+
+        result = await AsyncQueryableExtensions.SingleOrDefaultAsync(_queryable.Where(x => x.Value.ToUpper().Contains("no match")));
+
+        result.ShouldBeNull();
+
+        result = _queryable.SingleOrDefault(x => x.Value.ToUpper().Contains("no match"));
+
+        result.ShouldBeNull();
+
+        result = _queryable.Where(x => x.Value.ToUpper().Contains("no match")).SingleOrDefault();
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Should_throw_when_calling_single_or_default_with_predicate_on_query_with_multiple_results()
+    {
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+        CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(() => EntityFrameworkQueryableExtensions.SingleOrDefaultAsync(_queryable, x => x.Value.ToUpper().Contains("O")));
+        ex.Message.ShouldBe("Sequence contains more than one matching element");
+
+        ex = await Should.ThrowAsync<InvalidOperationException>(async () => await AsyncQueryableExtensions.SingleOrDefaultAsync(_queryable, x => x.Value.ToUpper().Contains("O")));
+        ex.Message.ShouldBe("Sequence contains more than one matching element");
+
+        ex = Should.Throw<InvalidOperationException>(() => _queryable.SingleOrDefault(x => x.Value.ToUpper().Contains("O")));
+        ex.Message.ShouldBe("Sequence contains more than one matching element");
+    }
+
+    [Fact]
+    public async Task Single_with_predicate_should_faile_if_no_match()
+    {
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+        CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(() => EntityFrameworkQueryableExtensions.SingleAsync(_queryable, x => x.Value.ToUpper().Contains("no match")));
+        ex.Message.ShouldBe("Sequence contains no matching element");
+
+        ex = await Should.ThrowAsync<InvalidOperationException>(async () => await AsyncQueryableExtensions.SingleAsync(_queryable, x => x.Value.ToUpper().Contains("no match")));
+        ex.Message.ShouldBe("Sequence contains no matching element");
+
+        ex = Should.Throw<InvalidOperationException>(() => _queryable.Single(x => x.Value.ToUpper().Contains("no match")));
+        ex.Message.ShouldBe("Sequence contains no matching element");
+    }
+}

--- a/test/Remote.Linq.Tests/Remote.Linq.Tests.csproj
+++ b/test/Remote.Linq.Tests/Remote.Linq.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Tests for Remote.Linq</Description>
-    <TargetFrameworks>net48;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Added support to query with the original ef core extension methods
Added support for IAsyncEnumerable<> / IAsyncQueryProvider to ef core
Added extension methods for configuration with support for cancellationToken 
Added STS additionally to LTS to supported SDKs
Update dependencies

Fixes https://github.com/6bee/Remote.Linq/issues/126

Did not commit this into `Remote.Linq.protobuf-net.csproj`:
```
  <ItemGroup>
    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
  </ItemGroup>
```
I think the CVE error (4.3.0 referenced) should go away with the updated protobuf reference in Aqua.Core ;-)